### PR TITLE
Feature/swbit 4260

### DIFF
--- a/packages/frontend/src/components/DocumentInfoForm.tsx
+++ b/packages/frontend/src/components/DocumentInfoForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import {
   colors,
@@ -26,6 +26,10 @@ const DocumentInfoForm: FC<DocumentInfoFormProps> = ({
   const [imageError, setImageError] = useState("");
   const [titleInput, setTitle] = useState(title);
   const [titleError, setTitleError] = useState(false);
+
+  useEffect(() => {
+    setTitle(title);
+  });
 
   const onFileSelected = (file: File) => {
     if (file.type.indexOf("image/") !== 0) {

--- a/packages/frontend/src/components/EditDocument.tsx
+++ b/packages/frontend/src/components/EditDocument.tsx
@@ -16,7 +16,6 @@ import {
   CREATE_DOCUMENT_MUTATION,
   UPDATE_DOCUMENT_MUTATION,
   PUBLISH_DOCUMENT_MUTATION,
-  ME_QUERY,
   SET_DOCUMENT_IMAGE_MUTATION
 } from "../apollo/queries";
 import { documentTypes } from "../config";
@@ -44,7 +43,7 @@ const EditDocument: FC<EditDocumentProps> = ({ folder, id, type }) => {
   const [isEditTitleVisible, setIsEditTitleVisible] = useState(false);
   const [tabIndex, setTabIndex] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [imageInterval, setImageInterval] = useState<NodeJS.Timeout>();
+  const [, setImageInterval] = useState<number>();
   const [firstLoad, setFirstLoad] = useState(true);
   const [error, setError] = useState(null);
   const [document, setDocument] = useState({

--- a/packages/frontend/src/components/EditDocument.tsx
+++ b/packages/frontend/src/components/EditDocument.tsx
@@ -203,7 +203,7 @@ const EditDocument: FC<EditDocumentProps> = ({ folder, id, type }) => {
         variables: {
           ...document,
           folder: folder,
-          title: document.title || "Documento sin título"
+          title: document.title || t("untitled-project")
         }
       }).catch(e => {
         return setError(e);
@@ -308,7 +308,11 @@ const EditDocument: FC<EditDocumentProps> = ({ folder, id, type }) => {
         description={description}
         image={image ? image.image : ""}
         onChange={({ title, description, image }) => {
-          const newDocument = { ...document, title, description };
+          const newDocument = {
+            ...document,
+            title: title || t("untitled-project"),
+            description
+          };
           updateImage(document.id, image, false);
           update(newDocument);
         }}

--- a/packages/frontend/src/components/EditDocument.tsx
+++ b/packages/frontend/src/components/EditDocument.tsx
@@ -256,7 +256,7 @@ const EditDocument: FC<EditDocumentProps> = ({ folder, id, type }) => {
   };
 
   const onSaveTitle = (title: string) => {
-    update({ ...document, title });
+    update({ ...document, title: title || t("untitled-project") });
     setIsEditTitleVisible(false);
   };
 


### PR DESCRIPTION
Arreglado "Si se pulsa en Cambiar o en Cancelar y el campo del nombre del documento se queda vacío, el documento no se llama 'Documento sin título'"