### PR TITLE
Feature/swbit 4553

### DIFF
--- a/packages/frontend/src/components/DocumentInfoForm.tsx
+++ b/packages/frontend/src/components/DocumentInfoForm.tsx
@@ -107,7 +107,11 @@ const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
             </FormLabel>
             <FormInput>
               <TextArea
-                value={description}
+                value={
+                  description === t("document-body-description")
+                    ? undefined
+                    : description
+                }
                 placeholder={t("document-info.placeholders.description")}
                 onChange={e => {
                   onChange({


### PR DESCRIPTION
Arrreglado "Al borrar la descripción de un documento, se sigue mostrando 'Sin descripción' aunque borremos"

https://jira.bq.com/browse/SWBIT-4553