### PR TITLE
 Refactor de nombres de documentos, carpetas, ejercicios y entregas

### DIFF
--- a/packages/api/migrations/20191226150216-foldersName.js
+++ b/packages/api/migrations/20191226150216-foldersName.js
@@ -1,0 +1,44 @@
+module.exports = {
+  async up(db, client) {
+    // TODO write your migration here.
+    // See https://github.com/seppevs/migrate-mongo/#creating-a-new-migration-script
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+    await db
+      .collection("documentmodels")
+      .updateMany({}, { $rename: { folder: "parentFolder" } });
+    await db
+      .collection("foldermodels")
+      .updateMany({}, { $rename: { parent: "parentFolder" } });
+    await db
+      .collection("submissionmodels")
+      .updateMany({}, { $rename: { title: "name" } });
+    await db
+      .collection("exercisemodels")
+      .updateMany({}, { $rename: { title: "name" } });
+    return db
+      .collection("documentmodels")
+      .updateMany({}, { $rename: { title: "name" } });
+  },
+
+  async down(db, client) {
+    // TODO write the statements to rollback your migration (if possible)
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+    await db
+      .collection("documentmodels")
+      .updateMany({}, { $rename: { parentFolder: "folder" } });
+    await db
+      .collection("foldermodels")
+      .updateMany({}, { $rename: { parentFolder: "parent" } });
+    await db
+      .collection("submissionmodels")
+      .updateMany({}, { $rename: { name: "title" } });
+    await db
+      .collection("exercisemodels")
+      .updateMany({}, { $rename: { name: "title" } });
+    return db
+      .collection("documentmodels")
+      .updateMany({}, { $rename: { name: "title" } });
+  }
+};

--- a/packages/api/src/api-types.ts
+++ b/packages/api/src/api-types.ts
@@ -51,9 +51,9 @@ export interface IDocument {
   __typename?: "Document";
   id?: Maybe<Scalars["ObjectID"]>;
   user?: Maybe<Scalars["ObjectID"]>;
-  title: Scalars["String"];
+  name: Scalars["String"];
   type?: Maybe<Scalars["String"]>;
-  folder?: Maybe<Scalars["ObjectID"]>;
+  parentFolder?: Maybe<Scalars["ObjectID"]>;
   content?: Maybe<Scalars["String"]>;
   advancedMode?: Maybe<Scalars["Boolean"]>;
   cache?: Maybe<Scalars["String"]>;
@@ -74,9 +74,9 @@ export interface IDocument {
 
 export interface IDocumentIn {
   user?: Maybe<Scalars["ObjectID"]>;
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   type?: Maybe<Scalars["String"]>;
-  folder?: Maybe<Scalars["ObjectID"]>;
+  parentFolder?: Maybe<Scalars["ObjectID"]>;
   content?: Maybe<Scalars["String"]>;
   advancedMode?: Maybe<Scalars["Boolean"]>;
   cache?: Maybe<Scalars["String"]>;
@@ -97,7 +97,7 @@ export interface IExercise {
   id?: Maybe<Scalars["ObjectID"]>;
   document?: Maybe<Scalars["ObjectID"]>;
   user?: Maybe<Scalars["ObjectID"]>;
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   content?: Maybe<Scalars["String"]>;
   contentVersion?: Maybe<Scalars["Number"]>;
   cache?: Maybe<Scalars["String"]>;
@@ -116,7 +116,7 @@ export interface IExercise {
 
 export interface IExerciseIn {
   document?: Maybe<Scalars["ObjectID"]>;
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   code?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
   acceptSubmissions?: Maybe<Scalars["Boolean"]>;
@@ -178,11 +178,12 @@ export interface IMutation {
   sendForgotPasswordEmail?: Maybe<Scalars["String"]>;
   checkForgotPasswordToken?: Maybe<Scalars["Boolean"]>;
   updateForgotPassword?: Maybe<Scalars["String"]>;
-  deleteMyUser?: Maybe<IUser>;
+  deleteMyUser?: Maybe<Scalars["String"]>;
   updateUserData?: Maybe<IUser>;
   updateMyPassword?: Maybe<IUser>;
   updateMyPlan?: Maybe<Scalars["String"]>;
   sendChangeMyEmailToken?: Maybe<Scalars["String"]>;
+  checkTokenChangeEmail?: Maybe<Scalars["Boolean"]>;
   confirmChangeEmail?: Maybe<Scalars["String"]>;
   createDocument?: Maybe<IDocument>;
   deleteDocument?: Maybe<IDocument>;
@@ -284,6 +285,10 @@ export interface IMutationSendChangeMyEmailTokenArgs {
   newEmail: Scalars["String"];
 }
 
+export interface IMutationCheckTokenChangeEmailArgs {
+  token: Scalars["String"];
+}
+
 export interface IMutationConfirmChangeEmailArgs {
   token: Scalars["String"];
   password: Scalars["String"];
@@ -303,7 +308,7 @@ export interface IMutationDuplicateDocumentArgs {
   itemsPerPage?: Maybe<Scalars["Number"]>;
   order?: Maybe<Scalars["String"]>;
   searchTitle?: Maybe<Scalars["String"]>;
-  title: Scalars["String"];
+  name: Scalars["String"];
 }
 
 export interface IMutationUpdateDocumentArgs {
@@ -537,7 +542,7 @@ export interface IResource {
 export interface IResult {
   __typename?: "Result";
   id?: Maybe<Scalars["ObjectID"]>;
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   image?: Maybe<Scalars["String"]>;
   type?: Maybe<Scalars["String"]>;
   createdAt?: Maybe<Scalars["Date"]>;
@@ -576,7 +581,7 @@ export interface ISocialLogin {
 export interface ISubmission {
   __typename?: "Submission";
   id?: Maybe<Scalars["ObjectID"]>;
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   exercise?: Maybe<Scalars["ObjectID"]>;
   user?: Maybe<Scalars["ObjectID"]>;
   document?: Maybe<Scalars["ObjectID"]>;
@@ -599,7 +604,7 @@ export interface ISubmission {
 }
 
 export interface ISubmissionIn {
-  title?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   finished?: Maybe<Scalars["Boolean"]>;
   studentComment?: Maybe<Scalars["String"]>;
   studentNick?: Maybe<Scalars["String"]>;
@@ -659,6 +664,7 @@ export interface IUser {
   updatedAt?: Maybe<Scalars["Date"]>;
   lastLogin?: Maybe<Scalars["Date"]>;
   rootFolder?: Maybe<Scalars["ObjectID"]>;
+  socialLogin?: Maybe<Scalars["Boolean"]>;
   documents?: Maybe<Array<Maybe<IDocument>>>;
   folders?: Maybe<Array<Maybe<IFolder>>>;
 }
@@ -943,9 +949,9 @@ export type IDocumentResolvers<
 > = ResolversObject<{
   id?: Resolver<Maybe<IResolversTypes["ObjectID"]>, ParentType, ContextType>;
   user?: Resolver<Maybe<IResolversTypes["ObjectID"]>, ParentType, ContextType>;
-  title?: Resolver<IResolversTypes["String"], ParentType, ContextType>;
+  name?: Resolver<IResolversTypes["String"], ParentType, ContextType>;
   type?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
-  folder?: Resolver<
+  parentFolder?: Resolver<
     Maybe<IResolversTypes["ObjectID"]>,
     ParentType,
     ContextType
@@ -1032,7 +1038,7 @@ export type IExerciseResolvers<
     ContextType
   >;
   user?: Resolver<Maybe<IResolversTypes["ObjectID"]>, ParentType, ContextType>;
-  title?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
+  name?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   content?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   contentVersion?: Resolver<
     Maybe<IResolversTypes["Number"]>,
@@ -1234,7 +1240,7 @@ export type IMutationResolvers<
     IMutationUpdateForgotPasswordArgs
   >;
   deleteMyUser?: Resolver<
-    Maybe<IResolversTypes["User"]>,
+    Maybe<IResolversTypes["String"]>,
     ParentType,
     ContextType,
     RequireFields<IMutationDeleteMyUserArgs, "password">
@@ -1266,6 +1272,12 @@ export type IMutationResolvers<
     ContextType,
     RequireFields<IMutationSendChangeMyEmailTokenArgs, "newEmail">
   >;
+  checkTokenChangeEmail?: Resolver<
+    Maybe<IResolversTypes["Boolean"]>,
+    ParentType,
+    ContextType,
+    RequireFields<IMutationCheckTokenChangeEmailArgs, "token">
+  >;
   confirmChangeEmail?: Resolver<
     Maybe<IResolversTypes["String"]>,
     ParentType,
@@ -1288,7 +1300,7 @@ export type IMutationResolvers<
     Maybe<IResolversTypes["DuplicateDocument"]>,
     ParentType,
     ContextType,
-    RequireFields<IMutationDuplicateDocumentArgs, "documentID" | "title">
+    RequireFields<IMutationDuplicateDocumentArgs, "documentID" | "name">
   >;
   updateDocument?: Resolver<
     Maybe<IResolversTypes["Document"]>,
@@ -1639,7 +1651,7 @@ export type IResultResolvers<
   ParentType extends IResolversParentTypes["Result"] = IResolversParentTypes["Result"]
 > = ResolversObject<{
   id?: Resolver<Maybe<IResolversTypes["ObjectID"]>, ParentType, ContextType>;
-  title?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
+  name?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   image?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   type?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   createdAt?: Resolver<Maybe<IResolversTypes["Date"]>, ParentType, ContextType>;
@@ -1702,7 +1714,7 @@ export type ISubmissionResolvers<
   ParentType extends IResolversParentTypes["Submission"] = IResolversParentTypes["Submission"]
 > = ResolversObject<{
   id?: Resolver<Maybe<IResolversTypes["ObjectID"]>, ParentType, ContextType>;
-  title?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
+  name?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   exercise?: Resolver<
     Maybe<IResolversTypes["ObjectID"]>,
     ParentType,
@@ -1895,6 +1907,11 @@ export type IUserResolvers<
   lastLogin?: Resolver<Maybe<IResolversTypes["Date"]>, ParentType, ContextType>;
   rootFolder?: Resolver<
     Maybe<IResolversTypes["ObjectID"]>,
+    ParentType,
+    ContextType
+  >;
+  socialLogin?: Resolver<
+    Maybe<IResolversTypes["Boolean"]>,
     ParentType,
     ContextType
   >;

--- a/packages/api/src/api-types.ts
+++ b/packages/api/src/api-types.ts
@@ -142,7 +142,7 @@ export interface IFolder {
   user?: Maybe<Scalars["ObjectID"]>;
   documentsID?: Maybe<Array<Maybe<Scalars["ObjectID"]>>>;
   foldersID?: Maybe<Array<Maybe<Scalars["ObjectID"]>>>;
-  parent?: Maybe<Scalars["ObjectID"]>;
+  parentFolder?: Maybe<Scalars["ObjectID"]>;
   createdAt?: Maybe<Scalars["Date"]>;
   updatedAt?: Maybe<Scalars["Date"]>;
   documents?: Maybe<Array<Maybe<IDocument>>>;
@@ -155,7 +155,7 @@ export interface IFolderIn {
   user?: Maybe<Scalars["ObjectID"]>;
   documentsID?: Maybe<Array<Maybe<Scalars["ObjectID"]>>>;
   foldersID?: Maybe<Array<Maybe<Scalars["ObjectID"]>>>;
-  parent?: Maybe<Scalars["ObjectID"]>;
+  parentFolder?: Maybe<Scalars["ObjectID"]>;
 }
 
 export interface ILoginOut {
@@ -547,7 +547,7 @@ export interface IResult {
   type?: Maybe<Scalars["String"]>;
   createdAt?: Maybe<Scalars["Date"]>;
   updatedAt?: Maybe<Scalars["Date"]>;
-  parent?: Maybe<Scalars["ObjectID"]>;
+  parentFolder?: Maybe<Scalars["ObjectID"]>;
 }
 
 export enum IRole {
@@ -1133,7 +1133,7 @@ export type IFolderResolvers<
     ParentType,
     ContextType
   >;
-  parent?: Resolver<
+  parentFolder?: Resolver<
     Maybe<IResolversTypes["ObjectID"]>,
     ParentType,
     ContextType
@@ -1656,7 +1656,7 @@ export type IResultResolvers<
   type?: Resolver<Maybe<IResolversTypes["String"]>, ParentType, ContextType>;
   createdAt?: Resolver<Maybe<IResolversTypes["Date"]>, ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<IResolversTypes["Date"]>, ParentType, ContextType>;
-  parent?: Resolver<
+  parentFolder?: Resolver<
     Maybe<IResolversTypes["ObjectID"]>,
     ParentType,
     ContextType

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,17 +1,2 @@
-import * as Types from "./api-types";
-import * as ConfigParameters from "./config";
-
-export type IDocImageIn = Types.IDocImageIn;
-export type IDocument = Types.IDocument;
-export type IExercise = Types.IExercise;
-export type IFolder = Types.IFolder;
-export type IMutationLoginArgs = Types.IMutationLoginArgs;
-export type IResource = Types.IResource;
-export type IResult = Types.IResult;
-export type ISessionExpires = Types.ISessionExpires;
-export type ISocialLogin = Types.ISocialLogin;
-export type IUser = Types.IUser;
-export type IUserIn = Types.IUserIn;
-export type IUserStep1 = Types.IUserStep1;
-
-export const LIMIT_SIZE = ConfigParameters.LIMIT_SIZE;
+export * from "./api-types";
+export * from "./config";

--- a/packages/api/src/models/document.ts
+++ b/packages/api/src/models/document.ts
@@ -1,24 +1,16 @@
 import { Document, Model, model, Schema } from "mongoose";
 import timestamps from "mongoose-timestamp";
 import { CONTENT_VERSION } from "../config";
+import { ICommonProps } from "./interfaces";
 
-export interface IDocument extends Document {
-  user?: string;
-  title?: string;
-  type?: string;
-  folder?: string;
-  content?: string;
+export interface IDocument extends ICommonProps, Document {
+  parentFolder?: string;
   contentVersion?: number;
   advancedMode?: boolean;
-  cache?: string;
   image?: { image: string; isSnapshot: boolean };
   public: boolean;
   example: boolean;
-  createdAt?: Date;
-  updatedAt?: Date;
-  description?: string;
   version?: string;
-  resourcesID?: string[];
   exResourcesID?: string[];
 }
 
@@ -28,7 +20,7 @@ const documentMongSchema: Schema = new Schema({
     ref: "UserModel"
   },
 
-  title: {
+  name: {
     type: String,
     default: ""
   },
@@ -38,7 +30,7 @@ const documentMongSchema: Schema = new Schema({
     required: true
   },
 
-  folder: {
+  parentFolder: {
     type: Schema.Types.ObjectId,
     ref: "FolderModel"
   },

--- a/packages/api/src/models/exercise.ts
+++ b/packages/api/src/models/exercise.ts
@@ -1,22 +1,16 @@
 import { Document, Model, model, Schema } from "mongoose";
 import timestamps from "mongoose-timestamp";
 import { CONTENT_VERSION } from "../config";
+import { ICommonProps } from "./interfaces";
 
-export interface IExercise extends Document {
-  user?: string;
-  document?: string;
+export interface IExercise extends ICommonProps, Document {
   code?: string;
-  title?: string;
-  type?: string;
-  description: string;
   teacherName: string;
-  content?: string;
   contentVersion?: number;
-  cache?: string;
   acceptSubmissions?: boolean;
   expireDate?: Date;
   image: string;
-  resourcesID: string[];
+  document: string;
 }
 
 const exerciseMongSchema: Schema = new Schema({
@@ -40,7 +34,7 @@ const exerciseMongSchema: Schema = new Schema({
     default: "111111"
   },
 
-  title: {
+  name: {
     type: String,
     default: "New Exercise"
   },

--- a/packages/api/src/models/folder.ts
+++ b/packages/api/src/models/folder.ts
@@ -6,7 +6,7 @@ export interface IFolder extends Document {
   user?: string;
   documentsID?: [string];
   foldersID?: [string];
-  parent?: string;
+  parentFolder?: string;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -36,7 +36,7 @@ const folderMongSchema: Schema = new Schema({
     }
   ],
 
-  parent: {
+  parentFolder: {
     type: Schema.Types.ObjectId,
     ref: "FolderModel"
   }

--- a/packages/api/src/models/interfaces.ts
+++ b/packages/api/src/models/interfaces.ts
@@ -1,5 +1,16 @@
 import { ObjectID } from "bson";
 
+export interface ICommonProps {
+  user?: string;
+  name?: string;
+  type?: string;
+  description?: string;
+  content?: string;
+  cache?: string;
+  resourcesID?: string[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
 // User in token user interface
 export interface IUserInToken {
   email: string;

--- a/packages/api/src/models/submission.ts
+++ b/packages/api/src/models/submission.ts
@@ -1,20 +1,16 @@
 import { Document, Model, model, Schema } from "mongoose";
 import timestamps from "mongoose-timestamp";
 import { CONTENT_VERSION } from "../config";
+import { ICommonProps } from "./interfaces";
 
-export interface ISubmission extends Document {
+export interface ISubmission extends ICommonProps, Document {
   id: string;
-  user?: string;
-  title: string;
   exercise?: string;
   studentNick?: string;
   password?: string;
-  content?: string;
   contentVersion?: number;
-  cache?: string;
   finished?: boolean;
   comment?: string;
-  type: string;
   image: string;
   active: boolean;
 }
@@ -25,7 +21,7 @@ const submissionMongSchema: Schema = new Schema({
     ref: "UserModel"
   },
 
-  title: {
+  name: {
     type: String,
     default: "New Submission"
   },

--- a/packages/api/src/resolvers/exercise.ts
+++ b/packages/api/src/resolvers/exercise.ts
@@ -61,7 +61,7 @@ const exerciseResolver = {
       const exerciseNew: IExercise = new ExerciseModel({
         user: context.user.userID,
         document: docFather._id,
-        title: args.input.title,
+        name: args.input.name,
         code: newCode,
         type: docFather.type,
         acceptSubmissions: args.input.acceptSubmissions,
@@ -233,7 +233,7 @@ const exerciseResolver = {
       })).map(i => {
         return {
           id: i._id,
-          title: i.filename,
+          name: i.filename,
           type: i.type,
           size: i.size,
           thumbnail: i.image,

--- a/packages/api/src/resolvers/folder.ts
+++ b/packages/api/src/resolvers/folder.ts
@@ -59,11 +59,11 @@ const folderResolver = {
       const folderNew: IFolder = new FolderModel({
         name: args.input!.name,
         user: context.user.userID,
-        parent: args.input!.parent || user!.rootFolder
+        parentFolder: args.input!.parent || user!.rootFolder
       });
       const newFolder: IFolder = await FolderModel.create(folderNew);
       await FolderModel.findOneAndUpdate(
-        { _id: folderNew.parent },
+        { _id: folderNew.parentFolder },
         { $push: { foldersID: newFolder._id } },
         { new: true }
       );
@@ -104,7 +104,7 @@ const folderResolver = {
               context
             );
             await FolderModel.updateOne(
-              { _id: existFolder.parent },
+              { _id: existFolder.parentFolder },
               { $pull: { documentsID: document } },
               { new: true }
             );
@@ -120,7 +120,7 @@ const folderResolver = {
           }
         }
         await FolderModel.updateOne(
-          { _id: existFolder.parent },
+          { _id: existFolder.parentFolder },
           { $pull: { foldersID: existFolder._id } },
           { new: true }
         );
@@ -170,14 +170,14 @@ const folderResolver = {
             }
             await FolderModel.updateOne(
               // quito la carpeta de la carpeta en la que estuviera
-              { _id: fol.parent },
+              { _id: fol.parentFolder },
               { $pull: { foldersID: folder } },
               { new: true }
             );
             await FolderModel.updateOne(
               // actualizo la carpeta con el nuevo padre
               { _id: folder },
-              { parent: existFolder._id }
+              { parentFolder: existFolder._id }
             );
             await FolderModel.updateOne(
               { _id: existFolder._id },
@@ -200,14 +200,14 @@ const folderResolver = {
             }
             await FolderModel.updateOne(
               // quito el documento de la carpeta en la que estuviera
-              { _id: doc.folder },
+              { _id: doc.parentFolder },
               { $pull: { documentsID: document } },
               { new: true }
             );
             await DocumentModel.updateOne(
               // actualizo el documento con la nueva carpeta
               { _id: document },
-              { folder: existFolder._id }
+              { parentFolder: existFolder._id }
             );
             await FolderModel.updateOne(
               { _id: existFolder._id },
@@ -216,14 +216,17 @@ const folderResolver = {
             );
           }
         }
-        if (args.input!.parent && args.input!.parent !== existFolder.parent) {
+        if (
+          args.input!.parent &&
+          args.input!.parent !== existFolder.parentFolder
+        ) {
           // si se pasa un nuevo parent hay que modificarlo para que tenga al hijo en la lista
           await FolderModel.updateOne(
             { _id: args.input!.parent },
             { $push: { foldersID: existFolder._id } }
           );
           await FolderModel.updateOne(
-            { _id: existFolder.parent },
+            { _id: existFolder.parentFolder },
             { $pull: { foldersID: existFolder._id } }
           );
         }
@@ -238,7 +241,7 @@ const folderResolver = {
           {
             $set: {
               name: args.input!.name || existFolder.name,
-              parent: args.input!.parent || existFolder.parent
+              parentFolder: args.input!.parent || existFolder.parentFolder
             }
           },
           { new: true }

--- a/packages/api/src/resolvers/folder.ts
+++ b/packages/api/src/resolvers/folder.ts
@@ -48,8 +48,8 @@ const folderResolver = {
       const user: IUser | null = await UserModel.findOne({
         _id: context.user.userID
       });
-      if (args.input!.parent) {
-        if (!(await FolderModel.findOne({ _id: args.input!.parent }))) {
+      if (args.input!.parentFolder) {
+        if (!(await FolderModel.findOne({ _id: args.input!.parentFolder }))) {
           throw new ApolloError(
             "Parent folder does not exist",
             "PARENT_NOT_FOUND"
@@ -59,7 +59,7 @@ const folderResolver = {
       const folderNew: IFolder = new FolderModel({
         name: args.input!.name,
         user: context.user.userID,
-        parentFolder: args.input!.parent || user!.rootFolder
+        parentFolder: args.input!.parentFolder || user!.rootFolder
       });
       const newFolder: IFolder = await FolderModel.create(folderNew);
       await FolderModel.findOneAndUpdate(
@@ -144,8 +144,8 @@ const folderResolver = {
         _id: args.id,
         user: context.user.userID
       });
-      if (args.input!.parent) {
-        if (!(await FolderModel.findOne({ _id: args.input!.parent }))) {
+      if (args.input!.parentFolder) {
+        if (!(await FolderModel.findOne({ _id: args.input!.parentFolder }))) {
           throw new ApolloError(
             "Parent folder does not exist",
             "PARENT_NOT_FOUND"
@@ -217,12 +217,12 @@ const folderResolver = {
           }
         }
         if (
-          args.input!.parent &&
-          args.input!.parent !== existFolder.parentFolder
+          args.input!.parentFolder &&
+          args.input!.parentFolder !== existFolder.parentFolder
         ) {
           // si se pasa un nuevo parent hay que modificarlo para que tenga al hijo en la lista
           await FolderModel.updateOne(
-            { _id: args.input!.parent },
+            { _id: args.input!.parentFolder },
             { $push: { foldersID: existFolder._id } }
           );
           await FolderModel.updateOne(
@@ -241,7 +241,7 @@ const folderResolver = {
           {
             $set: {
               name: args.input!.name || existFolder.name,
-              parentFolder: args.input!.parent || existFolder.parentFolder
+              parentFolder: args.input!.parentFolder || existFolder.parentFolder
             }
           },
           { new: true }
@@ -297,7 +297,8 @@ const folderResolver = {
   Folder: {
     documents: async (folder: IFolder) =>
       DocumentModel.find({ folder: folder.id }),
-    folders: async (folder: IFolder) => FolderModel.find({ parent: folder.id }),
+    folders: async (folder: IFolder) =>
+      FolderModel.find({ parentFolder: folder.id }),
     parentsPath: async (folder: IFolder) => {
       const result = await getParentsPath(folder);
       return result;

--- a/packages/api/src/resolvers/submission.ts
+++ b/packages/api/src/resolvers/submission.ts
@@ -144,7 +144,7 @@ const submissionResolver = {
         cache: exFather.cache,
         user: exFather.user,
         document: exFather.document,
-        title: exFather.title,
+        name: exFather.name,
         type: exFather.type,
         active: true,
         contentVersion: exFather.contentVersion || CONTENT_VERSION

--- a/packages/api/src/resolvers/user.ts
+++ b/packages/api/src/resolvers/user.ts
@@ -331,11 +331,11 @@ const userResolver = {
           });
           await DocumentModel.updateMany(
             { user: contactFound._id },
-            { $set: { folder: userFolder._id } }
+            { $set: { parentFolder: userFolder._id } }
           );
           await FolderModel.updateMany(
             { user: contactFound._id, name: { $ne: "root" } },
-            { $set: { parent: userFolder._id } }
+            { $set: { parentFolder: userFolder._id } }
           );
           await UserModel.updateOne(
             { _id: contactFound._id },

--- a/packages/api/src/schemas/document.graphql
+++ b/packages/api/src/schemas/document.graphql
@@ -62,7 +62,7 @@ type Result {
   type: String
   createdAt: Date
   updatedAt: Date
-  parent: ObjectID
+  parentFolder: ObjectID
 }
 
 type Document {

--- a/packages/api/src/schemas/document.graphql
+++ b/packages/api/src/schemas/document.graphql
@@ -30,7 +30,7 @@ type Mutation {
     itemsPerPage: Number
     order: String
     searchTitle: String
-    title: String!
+    name: String!
   ): DuplicateDocument @authRequired(requires: [USER])
   updateDocument(id: ObjectID!, input: DocumentIn): Document
     @authRequired(requires: [USER])
@@ -57,7 +57,7 @@ type DocsAndFolders {
 
 type Result {
   id: ObjectID
-  title: String
+  name: String
   image: String
   type: String
   createdAt: Date
@@ -68,9 +68,9 @@ type Result {
 type Document {
   id: ObjectID
   user: ObjectID
-  title: String!
+  name: String!
   type: String
-  folder: ObjectID
+  parentFolder: ObjectID
   content: String
   advancedMode: Boolean
   cache: String
@@ -101,9 +101,9 @@ input DocImageIn {
 
 input DocumentIn {
   user: ObjectID
-  title: String
+  name: String
   type: String
-  folder: ObjectID
+  parentFolder: ObjectID
   content: String
   advancedMode: Boolean
   cache: String

--- a/packages/api/src/schemas/exercise.graphql
+++ b/packages/api/src/schemas/exercise.graphql
@@ -25,7 +25,7 @@ type Exercise {
   id: ObjectID
   document: ObjectID
   user: ObjectID
-  title: String
+  name: String
   content: String
   contentVersion: Number
   cache: String
@@ -44,7 +44,7 @@ type Exercise {
 
 input ExerciseIn {
   document: ObjectID
-  title: String
+  name: String
   code: String
   description: String
   acceptSubmissions: Boolean

--- a/packages/api/src/schemas/folder.graphql
+++ b/packages/api/src/schemas/folder.graphql
@@ -24,7 +24,7 @@ type Folder {
   user: ObjectID
   documentsID: [ObjectID]
   foldersID: [ObjectID]
-  parent: ObjectID
+  parentFolder: ObjectID
   createdAt: Date
   updatedAt: Date
   documents: [Document]
@@ -37,5 +37,5 @@ input FolderIn {
   user: ObjectID
   documentsID: [ObjectID]
   foldersID: [ObjectID]
-  parent: ObjectID
+  parentFolder: ObjectID
 }

--- a/packages/api/src/schemas/scalars.graphql
+++ b/packages/api/src/schemas/scalars.graphql
@@ -23,3 +23,15 @@ type SessionExpires {
   showSessionWarningSecs: Number
   expiredSession: Boolean
 }
+
+type CommonProps {
+  id: ObjectID
+  user: ObjectID
+  name: String!
+  type: String
+  content: String
+  cache: String
+  description: String
+  createdAt: Date
+  updatedAt: Date
+}

--- a/packages/api/src/schemas/submission.graphql
+++ b/packages/api/src/schemas/submission.graphql
@@ -52,7 +52,7 @@ type Subscription {
 
 type Submission {
   id: ObjectID
-  title: String
+  name: String
   exercise: ObjectID
   user: ObjectID
   document: ObjectID
@@ -74,7 +74,7 @@ type Submission {
   active: Boolean
 }
 input SubmissionIn {
-  title: String
+  name: String
   finished: Boolean
   studentComment: String
   studentNick: String

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -41,8 +41,16 @@ export const sortByUpdatedAt = (a, b) => {
 
 export const sortByTitleAZ = (a, b) => {
   try {
-    const aTitle = a && a.name.toLowerCase();
-    const bTitle = b && b.name.toLowerCase();
+    let aTitle: string = "";
+    let bTitle: string = "";
+    if (a && a.name && b && b.name) {
+      aTitle = a.name.toLowerCase();
+      bTitle = b.name.toLowerCase();
+    }
+    if (a && a.title && b && b.title) {
+      aTitle = a.title.toLowerCase();
+      bTitle = b.title.toLowerCase();
+    }
     return aTitle === bTitle ? 0 : aTitle < bTitle ? -1 : 1;
   } catch (e) {
     return undefined;
@@ -51,8 +59,17 @@ export const sortByTitleAZ = (a, b) => {
 
 export const sortByTitleZA = (a, b) => {
   try {
-    const aTitle = a && a.name.toLowerCase();
-    const bTitle = b && b.name.toLowerCase();
+    let aTitle: string = "";
+    let bTitle: string = "";
+    if (a && a.name && b && b.name) {
+      aTitle = a.name.toLowerCase();
+      bTitle = b.name.toLowerCase();
+      return aTitle === bTitle ? 0 : aTitle > bTitle ? -1 : 1;
+    }
+    if (a && a.title && b && b.title) {
+      aTitle = a.title.toLowerCase();
+      bTitle = b.title.toLowerCase();
+    }
     return aTitle === bTitle ? 0 : aTitle > bTitle ? -1 : 1;
   } catch (e) {
     return undefined;

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -12,7 +12,9 @@ export const getParentsPath = async (
   if (folder.name === "root") {
     return [folder, ...path];
   } else {
-    const parentFolder = await FolderModel.findOne({ _id: folder.parent });
+    const parentFolder = await FolderModel.findOne({
+      _id: folder.parentFolder
+    });
     const result = await getParentsPath(parentFolder!, [folder]);
     return [...result, ...path];
   }

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -41,8 +41,8 @@ export const sortByUpdatedAt = (a, b) => {
 
 export const sortByTitleAZ = (a, b) => {
   try {
-    const aTitle = a && a.title.toLowerCase();
-    const bTitle = b && b.title.toLowerCase();
+    const aTitle = a && a.name.toLowerCase();
+    const bTitle = b && b.name.toLowerCase();
     return aTitle === bTitle ? 0 : aTitle < bTitle ? -1 : 1;
   } catch (e) {
     return undefined;
@@ -51,8 +51,8 @@ export const sortByTitleAZ = (a, b) => {
 
 export const sortByTitleZA = (a, b) => {
   try {
-    const aTitle = a && a.title.toLowerCase();
-    const bTitle = b && b.title.toLowerCase();
+    const aTitle = a && a.name.toLowerCase();
+    const bTitle = b && b.name.toLowerCase();
     return aTitle === bTitle ? 0 : aTitle > bTitle ? -1 : 1;
   } catch (e) {
     return undefined;

--- a/packages/frontend/next.config.js
+++ b/packages/frontend/next.config.js
@@ -6,6 +6,7 @@ const { parsed: localEnv } = require("dotenv").config();
 module.exports = withTM(
   withWorkers({
     transpileModules: [
+      "@bitbloq/api",
       "@bitbloq/3d",
       "@bitbloq/ui",
       "@bitbloq/lib3d",

--- a/packages/frontend/src/apollo/queries.ts
+++ b/packages/frontend/src/apollo/queries.ts
@@ -23,7 +23,7 @@ export const DOCUMENT_QUERY = gql`
     document(id: $id) {
       id
       type
-      title
+      name
       description
       content
       image {
@@ -38,7 +38,7 @@ export const DOCUMENT_QUERY = gql`
       }
       exercisesResources {
         id
-        title
+        name
         type
       }
     }
@@ -50,7 +50,7 @@ export const OPEN_PUBLIC_DOCUMENT_QUERY = gql`
     openPublicDocument(id: $id) {
       id
       type
-      title
+      name
       description
       content
       image {
@@ -80,7 +80,7 @@ export const DOCS_FOLDERS_PAGE_QUERY = gql`
     ) {
       result {
         id
-        title
+        name
         type
         createdAt
         updatedAt
@@ -108,7 +108,7 @@ export const DOCUMENTS_QUERY = gql`
     documents {
       id
       type
-      title
+      name
       createdAt
       image {
         image
@@ -135,7 +135,7 @@ export const ROOT_FOLDER_QUERY = gql`
       documents {
         id
         type
-        title
+        name
         createdAt
         image {
           image
@@ -162,7 +162,7 @@ export const FOLDER_QUERY = gql`
       documents {
         id
         type
-        title
+        name
         createdAt
         updatedAt
         image
@@ -171,7 +171,7 @@ export const FOLDER_QUERY = gql`
         content
         folder
         exercises {
-          title
+          name
           code
         }
       }
@@ -191,7 +191,7 @@ export const EXAMPLES_QUERY = gql`
     examples {
       id
       type
-      title
+      name
       image {
         image
         isSnapshot
@@ -203,7 +203,7 @@ export const EXAMPLES_QUERY = gql`
 export const CREATE_DOCUMENT_MUTATION = gql`
   mutation CreateDocument(
     $type: String!
-    $title: String!
+    $name: String!
     $description: String
     $content: String
     $advancedMode: Boolean
@@ -213,7 +213,7 @@ export const CREATE_DOCUMENT_MUTATION = gql`
     createDocument(
       input: {
         type: $type
-        title: $title
+        name: $name
         description: $description
         content: $content
         advancedMode: $advancedMode
@@ -234,7 +234,7 @@ export const DUPLICATE_DOCUMENT_MUTATION = gql`
     $itemsPerPage: Number
     $order: String
     $searchTitle: String
-    $title: String!
+    $name: String!
   ) {
     duplicateDocument(
       currentLocation: $currentLocation
@@ -242,7 +242,7 @@ export const DUPLICATE_DOCUMENT_MUTATION = gql`
       itemsPerPage: $itemsPerPage
       order: $order
       searchTitle: $searchTitle
-      title: $title
+      name: $name
     ) {
       document {
         id
@@ -299,7 +299,7 @@ export const SET_DOCUMENT_IMAGE_MUTATION = gql`
 export const UPDATE_DOCUMENT_MUTATION = gql`
   mutation UpdateDocument(
     $id: ObjectID!
-    $title: String
+    $name: String
     $content: String
     $description: String
     $advancedMode: Boolean
@@ -308,7 +308,7 @@ export const UPDATE_DOCUMENT_MUTATION = gql`
     updateDocument(
       id: $id
       input: {
-        title: $title
+        name: $name
         content: $content
         description: $description
         advancedMode: $advancedMode
@@ -365,7 +365,7 @@ export const EXERCISE_QUERY = gql`
     exercise(id: $id) {
       id
       type
-      title
+      name
       code
       teacherName
       content
@@ -375,7 +375,7 @@ export const EXERCISE_QUERY = gql`
         file
         id
         thumbnail
-        title
+        name
         type
       }
     }
@@ -397,7 +397,7 @@ export const EXERCISE_UPDATE_MUTATION = gql`
     updateExercise(id: $id, input: $input) {
       id
       type
-      title
+      name
       code
       teacherName
       content
@@ -418,7 +418,7 @@ export const EXERCISE_DELETE_MUTATION = gql`
 export const SUBMISSION_QUERY = gql`
   query Submission($id: ObjectID!) {
     submission(id: $id) {
-      title
+      name
       studentNick
       content
     }
@@ -714,7 +714,7 @@ export const GET_CLOUD_RESOURCES = gql`
         preview
         size
         thumbnail
-        title
+        name
         type
       }
     }

--- a/packages/frontend/src/apollo/queries.ts
+++ b/packages/frontend/src/apollo/queries.ts
@@ -29,7 +29,7 @@ export const DOCUMENT_QUERY = gql`
         image
         isSnapshot
       }
-      folder
+      parentFolder
       parentsPath {
         id
         name
@@ -37,7 +37,7 @@ export const DOCUMENT_QUERY = gql`
       exercises {
         id
         code
-        title
+        name
         acceptSubmissions
         createdAt
         submissions {
@@ -59,7 +59,7 @@ export const EDIT_DOCUMENT_QUERY = gql`
     document(id: $id) {
       id
       type
-      title
+      name
       description
       content
       image {
@@ -74,7 +74,7 @@ export const EDIT_DOCUMENT_QUERY = gql`
       }
       exercisesResources {
         id
-        name
+        title
         type
       }
     }
@@ -121,7 +121,7 @@ export const DOCS_FOLDERS_PAGE_QUERY = gql`
         createdAt
         updatedAt
         image
-        parent
+        parentFolder
       }
       parentsPath {
         id
@@ -191,7 +191,7 @@ export const FOLDER_QUERY = gql`
     folder(id: $id) {
       id
       name
-      parent
+      parentFolder
       parentsPath {
         id
         name
@@ -225,7 +225,7 @@ export const CREATE_DOCUMENT_MUTATION = gql`
     $description: String
     $content: String
     $advancedMode: Boolean
-    $folder: ObjectID
+    $parentFolder: ObjectID
     $image: DocImageIn
   ) {
     createDocument(
@@ -235,7 +235,7 @@ export const CREATE_DOCUMENT_MUTATION = gql`
         description: $description
         content: $content
         advancedMode: $advancedMode
-        folder: $folder
+        parentFolder: $parentFolder
         image: $image
       }
     ) {
@@ -321,7 +321,7 @@ export const UPDATE_DOCUMENT_MUTATION = gql`
     $content: String
     $description: String
     $advancedMode: Boolean
-    $folder: ObjectID
+    $parentFolder: ObjectID
   ) {
     updateDocument(
       id: $id
@@ -330,7 +330,7 @@ export const UPDATE_DOCUMENT_MUTATION = gql`
         content: $content
         description: $description
         advancedMode: $advancedMode
-        folder: $folder
+        parentFolder: $parentFolder
       }
     ) {
       id
@@ -393,7 +393,7 @@ export const EXERCISE_QUERY = gql`
         file
         id
         thumbnail
-        name
+        title
         type
       }
     }
@@ -434,8 +434,8 @@ export const EXERCISE_DELETE_MUTATION = gql`
 `;
 
 export const CREATE_EXERCISE_MUTATION = gql`
-  mutation CreateExercise($documentId: ObjectID!, $title: String!) {
-    createExercise(input: { document: $documentId, title: $title }) {
+  mutation CreateExercise($documentId: ObjectID!, $name: String!) {
+    createExercise(input: { document: $documentId, name: $name }) {
       id
     }
   }
@@ -756,7 +756,7 @@ export const GET_CLOUD_RESOURCES = gql`
         preview
         size
         thumbnail
-        name
+        title
         type
       }
     }

--- a/packages/frontend/src/components/Document.tsx
+++ b/packages/frontend/src/components/Document.tsx
@@ -327,7 +327,7 @@ class Document extends React.Component<any, DocumentState> {
                 variables: {
                   id: exerciseId,
                   input: {
-                    title: value || "Ejercicio sin título"
+                    name: value || "Ejercicio sin título"
                   }
                 },
                 refetchQueries: [

--- a/packages/frontend/src/components/Document.tsx
+++ b/packages/frontend/src/components/Document.tsx
@@ -60,9 +60,9 @@ class Document extends React.Component<any, DocumentState> {
       type: "folder"
     }));
 
-    breadParents.push({ route: "", text: document.title, type: "document" });
+    breadParents.push({ route: "", text: document.name, type: "document" });
 
-    return <Breadcrumbs links={breadParents} title={document.title} />;
+    return <Breadcrumbs links={breadParents} title={document.name} />;
   }
 
   public renderDocumentInfo(document, t) {
@@ -76,7 +76,7 @@ class Document extends React.Component<any, DocumentState> {
           <DocumentHeaderButton
             onClick={() =>
               window.open(
-                `/app/edit-document/${document.folder}/${document.type}/${document.id}`
+                `/app/edit-document/${document.parentFolder}/${document.type}/${document.id}`
               )
             }
           >
@@ -88,7 +88,7 @@ class Document extends React.Component<any, DocumentState> {
           <DocumentBodyInfo>
             <DocumentTypeTag document={document} />
             <DocumentTitle>
-              {document.title || t("document-body-title")}
+              {document.name || t("document-body-title")}
             </DocumentTitle>
             <DocumentDescription>
               {document.description || t("document-body-description")}
@@ -110,7 +110,7 @@ class Document extends React.Component<any, DocumentState> {
           <DocumentHeaderButton
             onClick={() =>
               window.open(
-                `/app/edit-document/${document.folder}/${document.type}/${document.id}`
+                `/app/edit-document/${document.parentFolder}/${document.type}/${document.id}`
               )
             }
           >
@@ -122,7 +122,7 @@ class Document extends React.Component<any, DocumentState> {
           <DocumentBodyInfo teacher>
             <DocumentTypeTag document={document} />
             <DocumentTitle>
-              {document.title || t("document-body-title")}
+              {document.name || t("document-body-title")}
             </DocumentTitle>
             <DocumentDescription>
               {document.description || t("document-body-description")}
@@ -281,7 +281,7 @@ class Document extends React.Component<any, DocumentState> {
               createExercise({
                 variables: {
                   documentId,
-                  title: value || "Ejercicio sin título"
+                  name: value || "Ejercicio sin título"
                 },
                 refetchQueries: [
                   {

--- a/packages/frontend/src/components/DocumentCard.tsx
+++ b/packages/frontend/src/components/DocumentCard.tsx
@@ -67,7 +67,6 @@ const DocumentCard: FC<IDocumentCardProps> = ({
       }
     }
   });
-
   return hidden ? (
     <></>
   ) : (
@@ -93,11 +92,11 @@ const DocumentCard: FC<IDocumentCardProps> = ({
       {document.type !== "folder" ? (
         <Info>
           <DocumentTypeTag small document={document} />
-          <Title>{document.title}</Title>
+          <Title>{document.name}</Title>
         </Info>
       ) : (
         <Info folder>
-          <Title folder>{document.title}</Title>
+          <Title folder>{document.name}</Title>
         </Info>
       )}
       {children}

--- a/packages/frontend/src/components/DocumentInfo.tsx
+++ b/packages/frontend/src/components/DocumentInfo.tsx
@@ -10,13 +10,13 @@ interface IDocumentInfoProps {
 }
 
 const DocumentInfo: FC<IDocumentInfoProps> = ({ document, onGotoDocument }) => {
-  const { title, description, image } = document;
+  const { name, description, image } = document;
 
   return (
     <Container>
       <Left>
         <LeftContent>
-          <h2>{title}</h2>
+          <h2>{name}</h2>
           <Image
             src={
               (image as IDocumentImage).image!

--- a/packages/frontend/src/components/DocumentInfoForm.tsx
+++ b/packages/frontend/src/components/DocumentInfoForm.tsx
@@ -15,7 +15,7 @@ import { IResource, ResourcesTypes } from "../types";
 import { LIMIT_SIZE } from "../../../api/src/config";
 
 export interface IDocumentInfoFormProps {
-  title?: string;
+  name?: string;
   description?: string;
   documentId: string;
   image: string;
@@ -25,14 +25,14 @@ export interface IDocumentInfoFormProps {
   resources?: IResource[];
   resourcesTypesAccepted: ResourcesTypes[];
   onChange: (newValues: {
-    title?: string;
+    name?: string;
     description?: string;
     image?: File;
   }) => void;
 }
 
 const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
-  title,
+  name,
   description,
   documentId,
   image,
@@ -44,16 +44,16 @@ const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
   onChange
 }) => {
   const [imageError, setImageError] = useState("");
-  const [titleInput, setTitle] = useState(title);
-  const [titleError, setTitleError] = useState(false);
-  const [titleFocused, setTitleFocused] = useState(false);
+  const [nameInput, setName] = useState(name);
+  const [nameError, setNameError] = useState(false);
+  const [nameFocused, setNameFocused] = useState(false);
   const t = useTranslate();
 
   useEffect(() => {
-    if (!titleFocused) {
-      setTitle(title);
+    if (!nameFocused) {
+      setName(name);
     }
-  }, [title, titleFocused]);
+  }, [name, nameFocused]);
 
   const onFileSelected = (file: File) => {
     if (
@@ -66,7 +66,7 @@ const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
       setImageError(t("document-info.errors.image-size"));
     } else {
       onChange({
-        title,
+        name,
         description,
         image: file
       });
@@ -84,24 +84,24 @@ const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
             </FormLabel>
             <FormInput>
               <Input
-                value={titleInput}
+                value={nameInput}
                 placeholder={t("document-info.placeholders.title")}
                 onChange={e => {
                   const value: string = e.target.value;
                   if (isValidName(value)) {
-                    setTitleError(false);
+                    setNameError(false);
                     onChange({
-                      title: value,
+                      name: value,
                       description
                     });
                   } else {
-                    setTitleError(true);
+                    setNameError(true);
                   }
-                  setTitle(value);
+                  setName(value);
                 }}
-                error={titleError}
-                onFocus={() => setTitleFocused(true)}
-                onBlur={() => setTitleFocused(false)}
+                error={nameError}
+                onFocus={() => setNameFocused(true)}
+                onBlur={() => setNameFocused(false)}
               />
             </FormInput>
           </FormRow>
@@ -119,7 +119,7 @@ const DocumentInfoForm: FC<IDocumentInfoFormProps> = ({
                 placeholder={t("document-info.placeholders.description")}
                 onChange={e => {
                   onChange({
-                    title,
+                    name,
                     description: e.target.value
                   });
                 }}

--- a/packages/frontend/src/components/DocumentList.tsx
+++ b/packages/frontend/src/components/DocumentList.tsx
@@ -262,7 +262,7 @@ const DocumentList: FC<IDocumentListProps> = ({
     if (selectedToMove.id) {
       setSelectedToMove({ id: "" });
     } else {
-      setSelectedToMove({ id: document.id!, parent: document.parent! });
+      setSelectedToMove({ id: document.id!, parent: document.parentFolder! });
     }
   };
   const onMoveFolderClick = async (
@@ -273,7 +273,7 @@ const DocumentList: FC<IDocumentListProps> = ({
     if (selectedToMove.id) {
       setSelectedToMove({ id: "" });
     } else {
-      setSelectedToMove({ id: folder.id!, parent: folder.parent! });
+      setSelectedToMove({ id: folder.id!, parent: folder.parentFolder! });
     }
   };
 
@@ -299,7 +299,10 @@ const DocumentList: FC<IDocumentListProps> = ({
       e.stopPropagation();
     }
     await updateDocument({
-      variables: { id: documentId || selectedToMove.id, folder: folder.id }
+      variables: {
+        id: documentId || selectedToMove.id,
+        parentFolder: folder.id
+      }
     });
     onMove();
   };

--- a/packages/frontend/src/components/DocumentList.tsx
+++ b/packages/frontend/src/components/DocumentList.tsx
@@ -163,10 +163,9 @@ const DocumentList: FC<IDocumentListProps> = ({
   ) => {
     e.stopPropagation();
     setSelectedToMove({ id: "" });
-    // TODO: remove cast to IDocument after IFolder type refactor
     setEditFolderNameModal({
       id: folder.id!,
-      name: (folder as IDocument).name
+      name: folder.name || undefined
     });
   };
 

--- a/packages/frontend/src/components/DocumentList.tsx
+++ b/packages/frontend/src/components/DocumentList.tsx
@@ -7,7 +7,8 @@ import { css } from "@emotion/core";
 import {
   IDocument,
   IFolder,
-  IResult as IDocsAndFols
+  IResult as IDocsAndFols,
+  IDuplicateDocument
 } from "../../../api/src/api-types";
 import {
   UPDATE_DOCUMENT_MUTATION,
@@ -58,7 +59,7 @@ const DocumentList: FC<IDocumentListProps> = ({
   interface IState {
     id: string;
     name?: string;
-    parent?: string;
+    parentFolder?: string;
     type?: string;
   }
 
@@ -235,9 +236,9 @@ const DocumentList: FC<IDocumentListProps> = ({
     if (newName.length >= 64) {
       newName = newName.slice(0, 63);
     }
-    const result = await duplicateDocument({
+    const result: IDuplicateDocument = await duplicateDocument({
       variables: {
-        currentLocation,
+        currentLocation: currentLocation.id,
         documentID: document.id,
         order,
         searchTitle: searchText,
@@ -246,8 +247,7 @@ const DocumentList: FC<IDocumentListProps> = ({
     }).catch(catchError => {
       return catchError;
     });
-
-    const { page } = result.data.duplicateDocument;
+    const { page } = result;
 
     if (page) {
       selectPage(page);
@@ -262,7 +262,10 @@ const DocumentList: FC<IDocumentListProps> = ({
     if (selectedToMove.id) {
       setSelectedToMove({ id: "" });
     } else {
-      setSelectedToMove({ id: document.id!, parent: document.parentFolder! });
+      setSelectedToMove({
+        id: document.id!,
+        parentFolder: document.parentFolder!
+      });
     }
   };
   const onMoveFolderClick = async (
@@ -273,7 +276,7 @@ const DocumentList: FC<IDocumentListProps> = ({
     if (selectedToMove.id) {
       setSelectedToMove({ id: "" });
     } else {
-      setSelectedToMove({ id: folder.id!, parent: folder.parentFolder! });
+      setSelectedToMove({ id: folder.id!, parentFolder: folder.parentFolder! });
     }
   };
 
@@ -317,7 +320,7 @@ const DocumentList: FC<IDocumentListProps> = ({
     await updateFolder({
       variables: {
         id: folderMovedId || selectedToMove.id,
-        input: { parent: folderParent.id }
+        input: { parentFolder: folderParent.id }
       }
     });
     onMove();

--- a/packages/frontend/src/components/Documents.tsx
+++ b/packages/frontend/src/components/Documents.tsx
@@ -114,7 +114,7 @@ const Documents: FC<{ id?: string }> = ({ id }) => {
   const onCreateFolder = async (folderName: string) => {
     await createFolder({
       variables: {
-        input: { name: folderName, parent: currentLocation.id }
+        input: { name: folderName, parentFolder: currentLocation.id }
       }
     }).catch(e => {
       setError(e);

--- a/packages/frontend/src/components/DocumentsList.tsx
+++ b/packages/frontend/src/components/DocumentsList.tsx
@@ -74,7 +74,7 @@ const DocumentListComp: FC<IDocumentListProps> = ({
   });
   const [editDocTitleModal, setEditDocTitleModal] = useState<IState>({
     id: null,
-    title: null
+    name: null
   });
   const [editFolderNameModal, setEditFolderNameModal] = useState<IState>({
     id: null,
@@ -142,7 +142,7 @@ const DocumentListComp: FC<IDocumentListProps> = ({
       id: null,
       parent: null
     });
-    setEditDocTitleModal({ id: document.id!, title: document.title });
+    setEditDocTitleModal({ id: document.id!, name: document.name });
   };
 
   const onDocumentDeleteClick = (
@@ -233,11 +233,11 @@ const DocumentListComp: FC<IDocumentListProps> = ({
     await updateDocument({
       variables: {
         id: editDocTitleModal.id,
-        title: docTitle ? docTitle : "Documento sin título"
+        name: docTitle ? docTitle : "Documento sin título"
       }
     });
     refetchDocsFols();
-    setEditDocTitleModal({ id: null, title: null });
+    setEditDocTitleModal({ id: null, name: null });
     setMenuOpenId("");
   };
 
@@ -258,7 +258,7 @@ const DocumentListComp: FC<IDocumentListProps> = ({
     document: IDocument
   ) => {
     e.stopPropagation();
-    let newTitle: string = `${document.title} copia`;
+    let newTitle: string = `${document.name} copia`;
 
     if (newTitle.length >= 64) {
       newTitle = newTitle.slice(0, 63);
@@ -269,7 +269,7 @@ const DocumentListComp: FC<IDocumentListProps> = ({
         documentID: document.id,
         order,
         searchTitle: searchText,
-        title: newTitle
+        name: newTitle
       }
     }).catch(catchError => {
       console.log(catchError);
@@ -577,12 +577,12 @@ const DocumentListComp: FC<IDocumentListProps> = ({
       />
       {editDocTitleModal.id && (
         <EditInputModal
-          title={editDocTitleModal.title || undefined}
-          onCancel={() => setEditDocTitleModal({ id: null, title: null })}
+          title={editDocTitleModal.name || undefined}
+          onCancel={() => setEditDocTitleModal({ id: null, name: null })}
           onSave={onUpdateDocTitle}
           modalTitle="Cambiar nombre del documento"
           modalText="Nombre del documento"
-          placeholder={editDocTitleModal.title || "Placeholder"}
+          placeholder={editDocTitleModal.name || "Placeholder"}
           saveButton="Cambiar"
         />
       )}

--- a/packages/frontend/src/components/EditExercise.tsx
+++ b/packages/frontend/src/components/EditExercise.tsx
@@ -147,9 +147,7 @@ const EditExercise = ({ type, id }) => {
     });
     setIsSubmissionSuccessOpen(true);
   };
-
-  const { title, teacherName, resources } = exercise;
-
+  const { name, teacherName, resources } = exercise;
   const infoTab: IDocumentTab = {
     icon: <Icon name="info" />,
     label: t("tab-project-info"),
@@ -192,7 +190,7 @@ const EditExercise = ({ type, id }) => {
                   <Icon name="airplane-document" />
                 </TitleIcon>
                 <div>
-                  <TitleText>{title}</TitleText>
+                  <TitleText>{name}</TitleText>
                   <TeacherName>Profesor: {teacherName}</TeacherName>
                 </div>
               </Title>

--- a/packages/frontend/src/components/EditInputModal.tsx
+++ b/packages/frontend/src/components/EditInputModal.tsx
@@ -9,8 +9,8 @@ interface IEditInputModalProps {
   disabledSave?: boolean;
   errorText?: string;
   title?: string;
-  onSave: (title?: string) => any;
-  onChange?: (title?: string) => any;
+  onSave: (name?: string) => any;
+  onChange?: (name?: string) => any;
   onCancel: () => any;
   modalTitle: string;
   modalText: string;
@@ -41,7 +41,7 @@ const EditInputModal: FC<IEditInputModalProps> = props => {
     label,
     transparentOverlay
   } = props;
-  const [title, setTitle] = useState(props.title);
+  const [name, setName] = useState(props.title);
   const [error, setError] = useState<boolean | string>(false);
 
   useEffect(() => {
@@ -60,8 +60,8 @@ const EditInputModal: FC<IEditInputModalProps> = props => {
         <form
           onSubmit={e => {
             e.preventDefault();
-            if (type !== "email" || isValidEmail(title)) {
-              onSave(title);
+            if (type !== "email" || isValidEmail(name)) {
+              onSave(name);
             } else {
               setError(true);
             }
@@ -71,21 +71,21 @@ const EditInputModal: FC<IEditInputModalProps> = props => {
           {label && <InputLabel>{label}</InputLabel>}
           <Input
             autoFocus
-            placeholder={title || placeholder}
+            placeholder={name || placeholder}
             onChange={e => {
               const value: string = e.target.value;
               if (onChange) {
                 onChange(value);
               }
               if (!validateInput || type === "email" || isValidName(value)) {
-                setTitle(value);
+                setName(value);
                 setError(false);
               } else {
-                setTitle(value);
+                setName(value);
                 setError(true);
               }
             }}
-            value={title}
+            value={name}
             type={type || "text"}
             error={!!error}
           />

--- a/packages/frontend/src/components/ExerciseInfo.tsx
+++ b/packages/frontend/src/components/ExerciseInfo.tsx
@@ -9,7 +9,7 @@ enum TabType {
 }
 
 interface IExercise {
-  title: string;
+  name: string;
   description: string;
   image: string;
 }
@@ -20,7 +20,7 @@ interface IExerciseInfoProps {
 }
 
 const ExerciseInfo: React.FunctionComponent<IExerciseInfoProps> = ({
-  exercise: { title, description, image },
+  exercise: { name, description, image },
   onGotoExercise
 }) => {
   const [currentTab, setCurrentTab] = useState(TabType.Description);
@@ -29,7 +29,7 @@ const ExerciseInfo: React.FunctionComponent<IExerciseInfoProps> = ({
     <Container>
       <Left>
         <LeftContent>
-          <h2>{title}</h2>
+          <h2>{name}</h2>
           <Image src={image} />
         </LeftContent>
       </Left>

--- a/packages/frontend/src/components/ExercisePanel.tsx
+++ b/packages/frontend/src/components/ExercisePanel.tsx
@@ -57,7 +57,7 @@ const ExercisePanel: FC<IExercisePanelProps> = props => {
           </Toggle>
         </HeaderLeft>
         <HeaderCenter onClick={() => setOpen(!isOpen)}>
-          <Title>{exercise.title}</Title>
+          <Title>{exercise.name}</Title>
           <Date>{dayjs(exercise.createdAt).format("DD/MM/YY HH:mm")}</Date>
         </HeaderCenter>
         <DropDown
@@ -80,7 +80,7 @@ const ExercisePanel: FC<IExercisePanelProps> = props => {
                 iconName: "pencil",
                 label: t("menu-change-name"),
                 onClick() {
-                  onChangeName(exercise.title);
+                  onChangeName(exercise.name);
                 }
               },
               {

--- a/packages/frontend/src/components/FolderSelectorMenu.tsx
+++ b/packages/frontend/src/components/FolderSelectorMenu.tsx
@@ -67,7 +67,7 @@ const FolderSelectorMenu: FC<IFolderSelectorMenuProps> = ({
   useLayoutEffect(() => {
     const onClick = (e: MouseEvent) => {
       e.stopPropagation();
-      setSelectedFolder({ id: parent, name: "" });
+      setSelectedFolder({ id: parentFolder, name: "" });
     };
     if (parentButtonRef.current) {
       parentButtonRef.current.addEventListener("click", onClick);
@@ -83,7 +83,12 @@ const FolderSelectorMenu: FC<IFolderSelectorMenuProps> = ({
   if (loading) {
     return <FolderSelector>loading...</FolderSelector>;
   }
-  const { folders: foldersData, name: folderName, parent, id } = data.folder;
+  const {
+    folders: foldersData,
+    name: folderName,
+    parentFolder,
+    id
+  } = data.folder;
   return (
     <FolderSelector className={className}>
       <ParentButton ref={parentButtonRef}>

--- a/packages/frontend/src/components/FolderSelectorMenu.tsx
+++ b/packages/frontend/src/components/FolderSelectorMenu.tsx
@@ -110,7 +110,7 @@ const FolderSelectorMenu: FC<IFolderSelectorMenuProps> = ({
         {foldersData &&
           foldersData
             .filter(
-              (op: { id: string; parent: string }) =>
+              (op: { id: string; parentFolder: string }) =>
                 op.id !== selectedToMove.id
             )
             .map((folder, i) => (

--- a/packages/frontend/src/components/PublicDocument.tsx
+++ b/packages/frontend/src/components/PublicDocument.tsx
@@ -75,7 +75,7 @@ const PublicDocument: FC<IPublicDocumentProps> = ({ id, type }) => {
     const blob = new Blob([JSON.stringify(documentJSON)], {
       type: "text/json;charset=utf-8"
     });
-    saveAs(blob, `${document.title}.bitbloq`);
+    saveAs(blob, `${document.name}.bitbloq`);
   };
 
   const infoTab: IDocumentTab = {
@@ -124,7 +124,7 @@ const PublicDocument: FC<IPublicDocumentProps> = ({ id, type }) => {
                 <TitleIcon>
                   <Icon name="view-document" />
                 </TitleIcon>
-                <span>{document.title}</span>
+                <span>{document.name}</span>
               </>
             }
             headerButtons={[

--- a/packages/frontend/src/pages/app/edit-document/[folder]/[type]/[id].tsx
+++ b/packages/frontend/src/pages/app/edit-document/[folder]/[type]/[id].tsx
@@ -15,7 +15,6 @@ const EditDocumentPage: NextPage = () => {
   if (type !== "open" && (!documentType || !documentType.supported)) {
     return <ErrorPage statusCode={404} />;
   }
-
   return (
     <EditDocument
       id={id as string}

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -54,7 +54,7 @@ export interface IEditorProps {
 
 export interface IDocument {
   id: string;
-  title: string;
+  name: string;
   description: string;
   image: IDocumentImage | string;
   content: any;


### PR DESCRIPTION
Cambiados los títulos de documentos, ejercicios y entregas por "name".
Unificados los nombres de las carpetas padre para documentos y carpetas: "parentFolder".
Actualizada toda la API y mucha parte del front, faltan detallitos como placeholders.